### PR TITLE
Adding Norm Icon to Messages

### DIFF
--- a/src/controllers/LeaderboardChannelController.ts
+++ b/src/controllers/LeaderboardChannelController.ts
@@ -1,10 +1,10 @@
 import { MessageEmbed, TextChannel } from "discord.js";
 import { LeaderboardToString } from "../services/LeaderboardService";
 import deleteAllMessagesInTextChannel from "../utils/deleteAllMessagesInTextChannel";
-import { normIconURL } from "../types/common";
 
 export async function updateLeaderboardChannel(leaderboardChannel: TextChannel): Promise<void> {
   const leaderboardContent = await LeaderboardToString();
+  const normIconURL = "https://raw.githubusercontent.com/mattwells19/UNCC-Six-Mans.js/main/media/norm_still.png";
 
   await deleteAllMessagesInTextChannel(leaderboardChannel);
 

--- a/src/controllers/LeaderboardChannelController.ts
+++ b/src/controllers/LeaderboardChannelController.ts
@@ -1,6 +1,7 @@
 import { MessageEmbed, TextChannel } from "discord.js";
 import { LeaderboardToString } from "../services/LeaderboardService";
 import deleteAllMessagesInTextChannel from "../utils/deleteAllMessagesInTextChannel";
+import { normIconURL } from "../types/common";
 
 export async function updateLeaderboardChannel(leaderboardChannel: TextChannel): Promise<void> {
   const leaderboardContent = await LeaderboardToString();
@@ -13,7 +14,8 @@ export async function updateLeaderboardChannel(leaderboardChannel: TextChannel):
     return new MessageEmbed()
       .setColor("BLUE")
       .setTitle(`UNCC 6 Mans | Leaderboard ${embedCtr}`.trim())
-      .setDescription("```" + content + "```");
+      .setDescription("```" + content + "```")
+      .setThumbnail(normIconURL);
   });
 
   await leaderboardChannel.send({ embeds });

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -13,5 +13,3 @@ export interface BallChaser {
   team: Readonly<Team | null>;
   queueTime: Readonly<DateTime | null>;
 }
-
-export const normIconURL = "https://raw.githubusercontent.com/mattwells19/UNCC-Six-Mans.js/main/media/norm_still.png";

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -13,3 +13,5 @@ export interface BallChaser {
   team: Readonly<Team | null>;
   queueTime: Readonly<DateTime | null>;
 }
+
+export const normIconURL = "https://raw.githubusercontent.com/mattwells19/UNCC-Six-Mans.js/main/media/norm_still.png";


### PR DESCRIPTION
I noticed that the Norm icon was not added to the leaderboard messages.  This PR puts the Norm URL into a constant that all services can use and then adds it to the leaderboard controller.

![image](https://user-images.githubusercontent.com/14949544/152222536-0fe92ff1-aab1-41af-a7d7-7927b2622d00.png)
 