### PR TITLE
Adding Thumbnail to leaderboard

### DIFF
--- a/src/controllers/LeaderboardChannelController.ts
+++ b/src/controllers/LeaderboardChannelController.ts
@@ -9,11 +9,13 @@ export async function updateLeaderboardChannel(leaderboardChannel: TextChannel):
 
   const embeds = leaderboardContent.map((content, index) => {
     const embedCtr = leaderboardContent.length > 1 ? `(${index + 1}/${leaderboardContent.length})` : "";
+    const normIconURL = "https://raw.githubusercontent.com/mattwells19/UNCC-Six-Mans.js/main/media/norm_still.png";
 
     return new MessageEmbed()
       .setColor("BLUE")
       .setTitle(`UNCC 6 Mans | Leaderboard ${embedCtr}`.trim())
-      .setDescription("```" + content + "```");
+      .setDescription("```" + content + "```")
+      .setThumbnail(normIconURL);
   });
 
   await leaderboardChannel.send({ embeds });

--- a/src/controllers/LeaderboardChannelController.ts
+++ b/src/controllers/LeaderboardChannelController.ts
@@ -4,12 +4,12 @@ import deleteAllMessagesInTextChannel from "../utils/deleteAllMessagesInTextChan
 
 export async function updateLeaderboardChannel(leaderboardChannel: TextChannel): Promise<void> {
   const leaderboardContent = await LeaderboardToString();
+  const normIconURL = "https://raw.githubusercontent.com/mattwells19/UNCC-Six-Mans.js/main/media/norm_still.png";
 
   await deleteAllMessagesInTextChannel(leaderboardChannel);
 
   const embeds = leaderboardContent.map((content, index) => {
     const embedCtr = leaderboardContent.length > 1 ? `(${index + 1}/${leaderboardContent.length})` : "";
-    const normIconURL = "https://raw.githubusercontent.com/mattwells19/UNCC-Six-Mans.js/main/media/norm_still.png";
 
     return new MessageEmbed()
       .setColor("BLUE")


### PR DESCRIPTION
I noticed that the Norm icon was not added to the leaderboard messages.  This PR puts the Norm URL into a constant that all services can use and then adds it to the leaderboard controller.

![image](https://user-images.githubusercontent.com/14949544/152222536-0fe92ff1-aab1-41af-a7d7-7927b2622d00.png)
 