### PR TITLE
Captains choose

### DIFF
--- a/src/controllers/Interactions.ts
+++ b/src/controllers/Interactions.ts
@@ -66,6 +66,7 @@ export async function handleInteraction(buttonInteraction: ButtonInteraction): P
     }
 
     case ButtonCustomID.ChooseTeam: {
+      // 🐧 I think it would be useful to add a `isPlayerInQueue` function to the QueueRepository to handle this check
       const ballchasers = await QueueRepository.getAllBallChasersInQueue();
       if (!ballchasers.find((player) => player.id === buttonInteraction.user.id)) {
         await message.edit(MessageBuilder.fullQueueMessage(ballchasers));

--- a/src/controllers/Interactions.ts
+++ b/src/controllers/Interactions.ts
@@ -70,9 +70,7 @@ export async function handleInteraction(buttonInteraction: ButtonInteraction): P
     case ButtonCustomID.ChooseTeam: {
       const playerInQueue = await QueueRepository.isPlayerInQueue(buttonInteraction.user.id);
 
-      if (!playerInQueue) {
-        break;
-      } else {
+      if (playerInQueue) {
         const ballChasers = await QueueRepository.getAllBallChasersInQueue();
         const players = await setCaptains(ballChasers);
 

--- a/src/controllers/Interactions.ts
+++ b/src/controllers/Interactions.ts
@@ -2,7 +2,7 @@ import { ButtonInteraction, Message, TextChannel } from "discord.js";
 import QueueRepository from "../repositories/QueueRepository";
 import { joinQueue, leaveQueue } from "../services/QueueService";
 import MessageBuilder, { ButtonCustomID } from "../utils/MessageBuilder";
-import { createRandomMatch } from "../services/MatchService";
+import { blueCaptainsChoice, createRandomMatch } from "../services/MatchService";
 import { PlayerInQueue } from "../repositories/QueueRepository/types";
 
 export async function postCurrentQueue(queueChannel: TextChannel): Promise<void> {
@@ -46,6 +46,11 @@ export async function handleInteraction(buttonInteraction: ButtonInteraction): P
     }
 
     case ButtonCustomID.CreateRandomTeam: {
+      const ballchasers = await QueueRepository.getAllBallChasersInQueue();
+      if (!ballchasers.find((player) => player.id === buttonInteraction.user.id)) {
+        await message.edit(MessageBuilder.fullQueueMessage(ballchasers));
+      }
+
       const currentMatch = await createRandomMatch();
       const emptyQueue: PlayerInQueue[] = [];
 
@@ -57,6 +62,18 @@ export async function handleInteraction(buttonInteraction: ButtonInteraction): P
         await message.edit(MessageBuilder.queueMessage(emptyQueue)),
       ]);
 
+      break;
+    }
+
+    case ButtonCustomID.ChooseTeam: {
+      const ballchasers = await QueueRepository.getAllBallChasersInQueue();
+      if (!ballchasers.find((player) => player.id === buttonInteraction.user.id)) {
+        await message.edit(MessageBuilder.fullQueueMessage(ballchasers));
+      }
+
+      const players = await blueCaptainsChoice(null);
+
+      await message.edit(MessageBuilder.blueChooseMessage(players));
       break;
     }
   }

--- a/src/controllers/MenuInteractions.ts
+++ b/src/controllers/MenuInteractions.ts
@@ -14,6 +14,8 @@ export async function handleMenuInteraction(menuInteraction: SelectMenuInteracti
   switch (menuInteraction.customId) {
     case MenuCustomID.BlueSelect: {
       // If user is not the captain and not in dev
+      // 🐧 Might be handy to add a `QueueRepository.getCaptains()` function that returns the orange and blue captain to
+      // 🐧 do the captains checks
       const ballchasers = await QueueRepository.getAllBallChasersInQueue();
       if (
         !ballchasers.find(
@@ -21,6 +23,7 @@ export async function handleMenuInteraction(menuInteraction: SelectMenuInteracti
         ) &&
         !isDev
       ) {
+        // 🐧 do we need to edit the message? Can we just do nothing, or does that break things?
         await message.edit(MessageBuilder.blueChooseMessage(ballchasers));
         break;
       } else {

--- a/src/controllers/MenuInteractions.ts
+++ b/src/controllers/MenuInteractions.ts
@@ -1,0 +1,55 @@
+import { Message, SelectMenuInteraction } from "discord.js";
+import QueueRepository from "../repositories/QueueRepository";
+import { blueCaptainsChoice, orangeCaptainsChoice } from "../services/MatchService";
+import { createMatchFromChosenTeams } from "../services/TeamAssignmentService";
+import { Team } from "../types/common";
+import getEnvVariable from "../utils/getEnvVariable";
+import MessageBuilder, { MenuCustomID } from "../utils/MessageBuilder";
+
+export async function handleMenuInteraction(menuInteraction: SelectMenuInteraction): Promise<void> {
+  const message = menuInteraction.message;
+  if (!(message instanceof Message)) return;
+
+  const isDev = getEnvVariable("ENVIRONMENT") === "dev";
+
+  switch (menuInteraction.customId) {
+    case MenuCustomID.BlueSelect: {
+      // If user is not the captain and not in dev
+      const ballchasers = await QueueRepository.getAllBallChasersInQueue();
+      if (
+        !ballchasers.find(
+          (player) => player.isCap && player.team === Team.Blue && player.id === menuInteraction.user.id
+        ) &&
+        !isDev
+      ) {
+        await message.edit(MessageBuilder.blueChooseMessage(ballchasers));
+        break;
+      } else {
+        const updatedPlayers = await blueCaptainsChoice(menuInteraction.values[0]);
+
+        await message.edit(MessageBuilder.orangeChooseMessage(updatedPlayers));
+        break;
+      }
+    }
+    case MenuCustomID.OrangeSelect: {
+      // If user is not the captain and not in dev
+      const ballchasers = await QueueRepository.getAllBallChasersInQueue();
+      if (
+        !ballchasers.find(
+          (player) => player.isCap && player.team === Team.Orange && player.id === menuInteraction.user.id
+        ) &&
+        !isDev
+      ) {
+        await message.edit(MessageBuilder.orangeChooseMessage(ballchasers));
+        break;
+      } else {
+        await orangeCaptainsChoice(menuInteraction.values);
+
+        const match = await createMatchFromChosenTeams();
+
+        await message.edit(MessageBuilder.activeMatchMessage(match));
+        break;
+      }
+    }
+  }
+}

--- a/src/controllers/MenuInteractions.ts
+++ b/src/controllers/MenuInteractions.ts
@@ -1,7 +1,6 @@
 import { Message, SelectMenuInteraction } from "discord.js";
 import QueueRepository from "../repositories/QueueRepository";
-import { blueCaptainsChoice, orangeCaptainsChoice } from "../services/MatchService";
-import { createMatchFromChosenTeams } from "../services/TeamAssignmentService";
+import { blueCaptainsChoice, createMatchFromChosenTeams, orangeCaptainsChoice } from "../services/MatchService";
 import { Team } from "../types/common";
 import getEnvVariable from "../utils/getEnvVariable";
 import MessageBuilder, { MenuCustomID } from "../utils/MessageBuilder";

--- a/src/controllers/MenuInteractions.ts
+++ b/src/controllers/MenuInteractions.ts
@@ -27,7 +27,7 @@ export async function handleMenuInteraction(menuInteraction: SelectMenuInteracti
     }
     case MenuCustomID.OrangeSelect: {
       // If user is not the captain and not in dev
-      const isCaptain = await QueueRepository.isTeamCaptain(menuInteraction.user.id, Team.Blue);
+      const isCaptain = await QueueRepository.isTeamCaptain(menuInteraction.user.id, Team.Orange);
       if (isCaptain || isDev) {
         await orangePlayerChosen(menuInteraction.values);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { handleInteraction, postCurrentQueue } from "./controllers/Interactions"
 import getDiscordChannelById from "./utils/getDiscordChannelById";
 import getEnvVariable from "./utils/getEnvVariable";
 import { handleDevInteraction } from "./controllers/DevInteractions";
+import { handleMenuInteraction } from "./controllers/MenuInteractions";
 
 const NormClient = new Client({ intents: "GUILDS" });
 
@@ -29,11 +30,15 @@ NormClient.on("ready", () => {
 });
 
 NormClient.on("interactionCreate", async (interaction) => {
-  if (!interaction.isButton()) return;
-  await interaction.deferUpdate();
-
-  handleInteraction(interaction);
-  handleDevInteraction(interaction);
+  if (interaction.isButton()) {
+    await interaction.deferUpdate();
+    handleInteraction(interaction);
+    handleDevInteraction(interaction);
+  }
+  if (interaction.isSelectMenu()) {
+    await interaction.deferUpdate();
+    handleMenuInteraction(interaction);
+  }
 });
 
 NormClient.login(discordToken);

--- a/src/repositories/QueueRepository/QueueRepository.ts
+++ b/src/repositories/QueueRepository/QueueRepository.ts
@@ -140,14 +140,14 @@ export class QueueRepository {
   }
 
   async isTeamCaptain(ballChaserToCheck: string, teamToCheck: Team): Promise<boolean> {
-    const playerInMatch = await this.#Queue.count({
+    const isCaptain = await this.#Queue.count({
       where: {
         playerId: ballChaserToCheck,
         team: teamToCheck,
       },
     });
 
-    return playerInMatch > 0;
+    return isCaptain > 0;
   }
 }
 

--- a/src/repositories/QueueRepository/QueueRepository.ts
+++ b/src/repositories/QueueRepository/QueueRepository.ts
@@ -2,6 +2,7 @@ import { AddBallChaserToQueueInput, PlayerInQueue, QueueWithBallChaser, UpdateBa
 import { PrismaClient, Prisma } from "@prisma/client";
 import { DateTime } from "luxon";
 import LeaderboardRepository from "../LeaderboardRepository";
+import { Team } from "../../types/common";
 
 export class QueueRepository {
   #Queue: Prisma.QueueDelegate<Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined>;
@@ -126,6 +127,27 @@ export class QueueRepository {
         id: ballChaserToAdd.id,
       },
     });
+  }
+
+  async isPlayerInQueue(ballChaserToCheck: string): Promise<boolean> {
+    const playerInMatch = await this.#Queue.count({
+      where: {
+        playerId: ballChaserToCheck,
+      },
+    });
+
+    return playerInMatch > 0;
+  }
+
+  async isTeamCaptain(ballChaserToCheck: string, teamToCheck: Team): Promise<boolean> {
+    const playerInMatch = await this.#Queue.count({
+      where: {
+        playerId: ballChaserToCheck,
+        team: teamToCheck,
+      },
+    });
+
+    return playerInMatch > 0;
   }
 }
 

--- a/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
+++ b/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
@@ -209,24 +209,40 @@ describe("Queue Repository tests", () => {
     expect(DateTime.fromJSDate(playerInDb?.queueTime!).toISO()).toEqual(mockBallChaser.queueTime.toISO());
     expect(playerInDb?.team).toBeNull();
   });
-  it("check if player is in queue", async () => {
-    const mockBallChaser = BallChaserQueueBuilder.single();
-    await manuallyAddBallChaserToQueue(mockBallChaser);
+  describe("check if player is in queue", () => {
+    it("player is in queue", async () => {
+      const mockBallChaser = BallChaserQueueBuilder.single();
+      await manuallyAddBallChaserToQueue(mockBallChaser);
 
-    const playerInQueue = await QueueRepository.isPlayerInQueue(mockBallChaser.id);
-    const playerNotInQueue = await QueueRepository.isPlayerInQueue(faker.datatype.uuid());
+      const playerInQueue = await QueueRepository.isPlayerInQueue(mockBallChaser.id);
 
-    expect(playerInQueue).toEqual(true);
-    expect(playerNotInQueue).toEqual(false);
+      expect(playerInQueue).toEqual(true);
+    });
+    it("player is not in queue", async () => {
+      const mockBallChaser = BallChaserQueueBuilder.single();
+      await manuallyAddBallChaserToQueue(mockBallChaser);
+
+      const playerNotInQueue = await QueueRepository.isPlayerInQueue(faker.datatype.uuid());
+
+      expect(playerNotInQueue).toEqual(false);
+    });
   });
-  it("check if player is team captain", async () => {
-    const mockBallChaser = BallChaserQueueBuilder.single({ team: Team.Blue });
-    await manuallyAddBallChaserToQueue(mockBallChaser);
+  describe("check if player is team captain", () => {
+    it("player is team captain", async () => {
+      const mockBallChaser = BallChaserQueueBuilder.single({ team: Team.Blue });
+      await manuallyAddBallChaserToQueue(mockBallChaser);
 
-    const isCaptain = await QueueRepository.isTeamCaptain(mockBallChaser.id, Team.Blue);
-    const isNotCaptain = await QueueRepository.isTeamCaptain(faker.datatype.uuid(), Team.Orange);
+      const isCaptain = await QueueRepository.isTeamCaptain(mockBallChaser.id, Team.Blue);
 
-    expect(isCaptain).toEqual(true);
-    expect(isNotCaptain).toEqual(false);
+      expect(isCaptain).toEqual(true);
+    });
+    it("player is not team captain", async () => {
+      const mockBallChaser = BallChaserQueueBuilder.single({ team: Team.Blue });
+      await manuallyAddBallChaserToQueue(mockBallChaser);
+
+      const isNotCaptain = await QueueRepository.isTeamCaptain(faker.datatype.uuid(), Team.Orange);
+
+      expect(isNotCaptain).toEqual(false);
+    });
   });
 });

--- a/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
+++ b/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
@@ -229,20 +229,28 @@ describe("Queue Repository tests", () => {
   });
   describe("check if player is team captain", () => {
     it("player is team captain", async () => {
-      const mockBallChaser = BallChaserQueueBuilder.single({ team: Team.Blue });
+      const mockBallChaser = BallChaserQueueBuilder.single({ team: Team.Blue, isCap: true });
       await manuallyAddBallChaserToQueue(mockBallChaser);
 
       const isCaptain = await QueueRepository.isTeamCaptain(mockBallChaser.id, Team.Blue);
 
       expect(isCaptain).toEqual(true);
     });
-    it("player is not team captain", async () => {
-      const mockBallChaser = BallChaserQueueBuilder.single({ team: Team.Blue });
-      await manuallyAddBallChaserToQueue(mockBallChaser);
+    it("player is team captain but wrong team", async () => {
+      const mockBlueCaptain = BallChaserQueueBuilder.single({ team: Team.Blue, isCap: true });
+      await manuallyAddBallChaserToQueue(mockBlueCaptain);
 
-      const isNotCaptain = await QueueRepository.isTeamCaptain(faker.datatype.uuid(), Team.Orange);
+      const isCaptain = await QueueRepository.isTeamCaptain(faker.datatype.uuid(), Team.Orange);
 
-      expect(isNotCaptain).toEqual(false);
+      expect(isCaptain).toEqual(false);
+    });
+    it("player is team member but not captain", async () => {
+      const mockBlueTeamMember = BallChaserQueueBuilder.single({ team: Team.Blue, isCap: false });
+      await manuallyAddBallChaserToQueue(mockBlueTeamMember);
+
+      const isCaptain = await QueueRepository.isTeamCaptain(faker.datatype.uuid(), Team.Blue);
+
+      expect(isCaptain).toEqual(false);
     });
   });
 });

--- a/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
+++ b/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
@@ -240,7 +240,7 @@ describe("Queue Repository tests", () => {
       const mockBlueCaptain = BallChaserQueueBuilder.single({ team: Team.Blue, isCap: true });
       await manuallyAddBallChaserToQueue(mockBlueCaptain);
 
-      const isCaptain = await QueueRepository.isTeamCaptain(faker.datatype.uuid(), Team.Orange);
+      const isCaptain = await QueueRepository.isTeamCaptain(mockBlueCaptain.id, Team.Orange);
 
       expect(isCaptain).toEqual(false);
     });

--- a/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
+++ b/src/repositories/QueueRepository/__tests__/QueueRepository.int.spec.ts
@@ -214,29 +214,19 @@ describe("Queue Repository tests", () => {
     await manuallyAddBallChaserToQueue(mockBallChaser);
 
     const playerInQueue = await QueueRepository.isPlayerInQueue(mockBallChaser.id);
+    const playerNotInQueue = await QueueRepository.isPlayerInQueue(faker.datatype.uuid());
 
-    const playerInDb = await prisma.queue.count({
-      where: {
-        playerId: mockBallChaser.id,
-      },
-    });
-
-    expect(playerInDb).toEqual(1);
     expect(playerInQueue).toEqual(true);
+    expect(playerNotInQueue).toEqual(false);
   });
   it("check if player is team captain", async () => {
     const mockBallChaser = BallChaserQueueBuilder.single({ team: Team.Blue });
     await manuallyAddBallChaserToQueue(mockBallChaser);
 
     const isCaptain = await QueueRepository.isTeamCaptain(mockBallChaser.id, Team.Blue);
+    const isNotCaptain = await QueueRepository.isTeamCaptain(faker.datatype.uuid(), Team.Orange);
 
-    const playerInDb = await prisma.queue.count({
-      where: {
-        playerId: mockBallChaser.id,
-      },
-    });
-
-    expect(playerInDb).toEqual(1);
     expect(isCaptain).toEqual(true);
+    expect(isNotCaptain).toEqual(false);
   });
 });

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -1,7 +1,13 @@
-import { createRandomTeams } from "../services/TeamAssignmentService";
+import {
+  bluePlayerChosen,
+  createRandomTeams,
+  orangePlayerChosen,
+  setCaptains,
+} from "../services/TeamAssignmentService";
 import ActiveMatchRepository from "../repositories/ActiveMatchRepository";
 import QueueRepository from "../repositories/QueueRepository";
 import { NewActiveMatchInput } from "../repositories/ActiveMatchRepository/types";
+import { PlayerInQueue } from "../repositories/QueueRepository/types";
 
 export async function createRandomMatch(): Promise<Array<NewActiveMatchInput>> {
   const ballChasers = await QueueRepository.getAllBallChasersInQueue();
@@ -16,4 +22,20 @@ export async function createRandomMatch(): Promise<Array<NewActiveMatchInput>> {
   ]);
 
   return createdTeams;
+}
+
+export async function blueCaptainsChoice(chosenPlayers: string | null): Promise<ReadonlyArray<PlayerInQueue>> {
+  const ballChasers = await QueueRepository.getAllBallChasersInQueue();
+
+  if (!chosenPlayers) {
+    await setCaptains(ballChasers);
+  } else {
+    await bluePlayerChosen(chosenPlayers);
+  }
+
+  return await QueueRepository.getAllBallChasersInQueue();
+}
+
+export async function orangeCaptainsChoice(chosenPlayers: string[]): Promise<void> {
+  await orangePlayerChosen(chosenPlayers);
 }

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -22,9 +22,12 @@ export async function createRandomMatch(): Promise<Array<NewActiveMatchInput>> {
 export async function createMatchFromChosenTeams(): Promise<Array<NewActiveMatchInput>> {
   const createdTeams: NewActiveMatchInput[] = [];
 
-  //Update the last available player to blue and push all players into Active Match
+  //Sort the ballchasers so those without a team go at the end of the array for ActiveMatch embed visual fix
   const ballchasers = await QueueRepository.getAllBallChasersInQueue();
-  for (const p of ballchasers) {
+  const sortedBallChasers = ballchasers.slice().sort((a, b) => (a.team ?? 100) - (b.team ?? 100));
+
+  //Update the last available player to blue and push all players into Active Match
+  for (const p of sortedBallChasers) {
     if (p.team !== null) {
       createdTeams.push({ id: p.id, team: p.team });
     } else {

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -31,10 +31,6 @@ export async function createMatchFromChosenTeams(): Promise<Array<NewActiveMatch
     if (p.team !== null) {
       createdTeams.push({ id: p.id, team: p.team });
     } else {
-      await QueueRepository.updateBallChaserInQueue({
-        id: p.id,
-        team: Team.Blue,
-      });
       createdTeams.push({ id: p.id, team: Team.Blue });
     }
   }

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -1,13 +1,7 @@
-import {
-  bluePlayerChosen,
-  createRandomTeams,
-  orangePlayerChosen,
-  setCaptains,
-} from "../services/TeamAssignmentService";
+import { createRandomTeams } from "../services/TeamAssignmentService";
 import ActiveMatchRepository from "../repositories/ActiveMatchRepository";
 import QueueRepository from "../repositories/QueueRepository";
 import { NewActiveMatchInput } from "../repositories/ActiveMatchRepository/types";
-import { PlayerInQueue } from "../repositories/QueueRepository/types";
 import { Team } from "../types/common";
 
 export async function createRandomMatch(): Promise<Array<NewActiveMatchInput>> {
@@ -23,25 +17,6 @@ export async function createRandomMatch(): Promise<Array<NewActiveMatchInput>> {
   ]);
 
   return createdTeams;
-}
-
-// 🐧  I think this method is unnecessary. Just call `setCaptains` in Interaction.ts where you know it'll be null
-// 🐧 Then just call `bluePlayerChosen` in MenuInteraction.ts where you verify that a player in the queue was chosen
-export async function blueCaptainsChoice(chosenPlayers: string | null): Promise<ReadonlyArray<PlayerInQueue>> {
-  const ballChasers = await QueueRepository.getAllBallChasersInQueue();
-
-  if (!chosenPlayers) {
-    await setCaptains(ballChasers);
-  } else {
-    await bluePlayerChosen(chosenPlayers);
-  }
-
-  return await QueueRepository.getAllBallChasersInQueue();
-}
-
-// 🐧 Don't think this method is really necessary. Just call `orangePlayerChosen` in MenuInteraction.ts
-export async function orangeCaptainsChoice(chosenPlayers: string[]): Promise<void> {
-  await orangePlayerChosen(chosenPlayers);
 }
 
 export async function createMatchFromChosenTeams(): Promise<Array<NewActiveMatchInput>> {

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -25,6 +25,8 @@ export async function createRandomMatch(): Promise<Array<NewActiveMatchInput>> {
   return createdTeams;
 }
 
+// 🐧  I think this method is unnecessary. Just call `setCaptains` in Interaction.ts where you know it'll be null
+// 🐧 Then just call `bluePlayerChosen` in MenuInteraction.ts where you verify that a player in the queue was chosen
 export async function blueCaptainsChoice(chosenPlayers: string | null): Promise<ReadonlyArray<PlayerInQueue>> {
   const ballChasers = await QueueRepository.getAllBallChasersInQueue();
 
@@ -37,6 +39,7 @@ export async function blueCaptainsChoice(chosenPlayers: string | null): Promise<
   return await QueueRepository.getAllBallChasersInQueue();
 }
 
+// 🐧 Don't think this method is really necessary. Just call `orangePlayerChosen` in MenuInteraction.ts
 export async function orangeCaptainsChoice(chosenPlayers: string[]): Promise<void> {
   await orangePlayerChosen(chosenPlayers);
 }

--- a/src/services/MatchService.ts
+++ b/src/services/MatchService.ts
@@ -8,6 +8,7 @@ import ActiveMatchRepository from "../repositories/ActiveMatchRepository";
 import QueueRepository from "../repositories/QueueRepository";
 import { NewActiveMatchInput } from "../repositories/ActiveMatchRepository/types";
 import { PlayerInQueue } from "../repositories/QueueRepository/types";
+import { Team } from "../types/common";
 
 export async function createRandomMatch(): Promise<Array<NewActiveMatchInput>> {
   const ballChasers = await QueueRepository.getAllBallChasersInQueue();
@@ -38,4 +39,31 @@ export async function blueCaptainsChoice(chosenPlayers: string | null): Promise<
 
 export async function orangeCaptainsChoice(chosenPlayers: string[]): Promise<void> {
   await orangePlayerChosen(chosenPlayers);
+}
+
+export async function createMatchFromChosenTeams(): Promise<Array<NewActiveMatchInput>> {
+  const createdTeams: NewActiveMatchInput[] = [];
+
+  //Update the last available player to blue and push all players into Active Match
+  const ballchasers = await QueueRepository.getAllBallChasersInQueue();
+  for (const p of ballchasers) {
+    if (p.team !== null) {
+      createdTeams.push({ id: p.id, team: p.team });
+    } else {
+      await QueueRepository.updateBallChaserInQueue({
+        id: p.id,
+        team: Team.Blue,
+      });
+      createdTeams.push({ id: p.id, team: Team.Blue });
+    }
+  }
+
+  await Promise.all([
+    //Create Match
+    await ActiveMatchRepository.addActiveMatch(createdTeams),
+    //Match is created, reset the queue.
+    await QueueRepository.removeAllBallChasersFromQueue(),
+  ]);
+
+  return createdTeams;
 }

--- a/src/services/TeamAssignmentService.ts
+++ b/src/services/TeamAssignmentService.ts
@@ -80,30 +80,3 @@ export async function orangePlayerChosen(chosenPlayers: string[]): Promise<void>
     });
   }
 }
-
-export async function createMatchFromChosenTeams(): Promise<Array<NewActiveMatchInput>> {
-  const createdTeams: NewActiveMatchInput[] = [];
-
-  //Update the last available player to blue and push all players into Active Match
-  const ballchasers = await QueueRepository.getAllBallChasersInQueue();
-  for (const p of ballchasers) {
-    if (p.team !== null) {
-      createdTeams.push({ id: p.id, team: p.team });
-    } else {
-      await QueueRepository.updateBallChaserInQueue({
-        id: p.id,
-        team: Team.Blue,
-      });
-      createdTeams.push({ id: p.id, team: Team.Blue });
-    }
-  }
-
-  await Promise.all([
-    //Create Match
-    await ActiveMatchRepository.addActiveMatch(createdTeams),
-    //Match is created, reset the queue.
-    await QueueRepository.removeAllBallChasersFromQueue(),
-  ]);
-
-  return createdTeams;
-}

--- a/src/services/TeamAssignmentService.ts
+++ b/src/services/TeamAssignmentService.ts
@@ -1,4 +1,6 @@
+import ActiveMatchRepository from "../repositories/ActiveMatchRepository";
 import { NewActiveMatchInput } from "../repositories/ActiveMatchRepository/types";
+import QueueRepository from "../repositories/QueueRepository";
 import { PlayerInQueue } from "../repositories/QueueRepository/types";
 import { Team } from "../types/common";
 
@@ -42,4 +44,68 @@ export async function createRandomTeams(
   });
 
   return activeMatch;
+}
+
+export async function setCaptains(ballChasers: ReadonlyArray<PlayerInQueue>): Promise<Array<PlayerInQueue>> {
+  const sortedBallChaser = ballChasers.slice().sort((o, b) => o.mmr - b.mmr);
+  sortedBallChaser[0].team = Team.Blue;
+  sortedBallChaser[1].team = Team.Orange;
+
+  await Promise.all([
+    await QueueRepository.updateBallChaserInQueue({
+      id: sortedBallChaser[0].id,
+      isCap: true,
+      team: Team.Blue,
+    }),
+    await QueueRepository.updateBallChaserInQueue({
+      id: sortedBallChaser[1].id,
+      isCap: true,
+      team: Team.Orange,
+    }),
+  ]);
+
+  return sortedBallChaser;
+}
+
+export async function bluePlayerChosen(chosenPlayer: string): Promise<void> {
+  await QueueRepository.updateBallChaserInQueue({
+    id: chosenPlayer,
+    team: Team.Blue,
+  });
+}
+
+export async function orangePlayerChosen(chosenPlayers: string[]): Promise<void> {
+  for (const p of chosenPlayers) {
+    await QueueRepository.updateBallChaserInQueue({
+      id: p,
+      team: Team.Orange,
+    });
+  }
+}
+
+export async function createMatchFromChosenTeams(): Promise<Array<NewActiveMatchInput>> {
+  const createdTeams: NewActiveMatchInput[] = [];
+
+  //Update the last available player to blue and push all players into Active Match
+  const ballchasers = await QueueRepository.getAllBallChasersInQueue();
+  for (const p of ballchasers) {
+    if (p.team !== null) {
+      createdTeams.push({ id: p.id, team: p.team });
+    } else {
+      await QueueRepository.updateBallChaserInQueue({
+        id: p.id,
+        team: Team.Blue,
+      });
+      createdTeams.push({ id: p.id, team: Team.Blue });
+    }
+  }
+
+  await Promise.all([
+    //Create Match
+    await ActiveMatchRepository.addActiveMatch(createdTeams),
+    //Match is created, reset the queue.
+    await QueueRepository.removeAllBallChasersFromQueue(),
+  ]);
+
+  return createdTeams;
 }

--- a/src/services/TeamAssignmentService.ts
+++ b/src/services/TeamAssignmentService.ts
@@ -48,8 +48,6 @@ export async function createRandomTeams(
 
 export async function setCaptains(ballChasers: ReadonlyArray<PlayerInQueue>): Promise<Array<PlayerInQueue>> {
   const sortedBallChaser = ballChasers.slice().sort((o, b) => o.mmr - b.mmr);
-  sortedBallChaser[0].team = Team.Blue;
-  sortedBallChaser[1].team = Team.Orange;
 
   await Promise.all([
     await QueueRepository.updateBallChaserInQueue({

--- a/src/services/TeamAssignmentService.ts
+++ b/src/services/TeamAssignmentService.ts
@@ -49,6 +49,8 @@ export async function createRandomTeams(
 export async function setCaptains(ballChasers: ReadonlyArray<PlayerInQueue>): Promise<Array<PlayerInQueue>> {
   const sortedBallChaser = ballChasers.slice().sort((o, b) => o.mmr - b.mmr);
 
+  // 🐧 random thought: what if we allowed the second highest rated player in the queue sorted `sortedBallChaser[1]`
+  // 🐧 to pick first? Would that be slightly more balanced?
   await Promise.all([
     await QueueRepository.updateBallChaserInQueue({
       id: sortedBallChaser[0].id,
@@ -65,6 +67,7 @@ export async function setCaptains(ballChasers: ReadonlyArray<PlayerInQueue>): Pr
   return sortedBallChaser;
 }
 
+// 🐧 I'd probably add the check to make sure the player was in the queue as part of this function
 export async function bluePlayerChosen(chosenPlayer: string): Promise<void> {
   await QueueRepository.updateBallChaserInQueue({
     id: chosenPlayer,
@@ -72,6 +75,7 @@ export async function bluePlayerChosen(chosenPlayer: string): Promise<void> {
   });
 }
 
+// 🐧 I'd probably add the check to make sure both players are in the queue as part of this function
 export async function orangePlayerChosen(chosenPlayers: string[]): Promise<void> {
   for (const p of chosenPlayers) {
     await QueueRepository.updateBallChaserInQueue({

--- a/src/services/__tests__/MatchService.unit.spec.ts
+++ b/src/services/__tests__/MatchService.unit.spec.ts
@@ -30,17 +30,10 @@ describe("Match Service tests", () => {
 
       await createRandomMatch();
       const addMatchMock = jest.mocked(ActiveMatchRepository.addActiveMatch);
-
-      expect(addMatchMock).toHaveBeenCalled();
-    });
-    it("removes players from queue", async () => {
-      const mockBallChasers = BallChaserQueueBuilder.many(6);
-      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
-
-      await createRandomMatch();
       const removePlayersMock = jest.mocked(QueueRepository.removeAllBallChasersFromQueue);
 
       expect(removePlayersMock).toHaveBeenCalled();
+      expect(addMatchMock).toHaveBeenCalled();
     });
   });
   describe("Captains button was pressed", () => {
@@ -53,18 +46,13 @@ describe("Match Service tests", () => {
       jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
 
       const players = await createMatchFromChosenTeams();
-
-      expect(players.filter((player) => player.team === Team.Orange)).toHaveLength(3);
-      expect(players.filter((player) => player.team === Team.Blue)).toHaveLength(3);
-    });
-    it("removes players from queue", async () => {
-      const mockBallChasers = BallChaserQueueBuilder.many(6);
-      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
-
-      await createRandomMatch();
       const removePlayersMock = jest.mocked(QueueRepository.removeAllBallChasersFromQueue);
+      const addMatchMock = jest.mocked(ActiveMatchRepository.addActiveMatch);
 
       expect(removePlayersMock).toHaveBeenCalled();
+      expect(addMatchMock).toHaveBeenCalled();
+      expect(players.filter((player) => player.team === Team.Orange)).toHaveLength(3);
+      expect(players.filter((player) => player.team === Team.Blue)).toHaveLength(3);
     });
   });
 });

--- a/src/services/__tests__/MatchService.unit.spec.ts
+++ b/src/services/__tests__/MatchService.unit.spec.ts
@@ -45,17 +45,10 @@ describe("Match Service tests", () => {
   });
   describe("Captains button was pressed", () => {
     it("last available queueMember is placed on blue team", async () => {
-      const mockBallChasers: PlayerInQueue[] = [];
       const mockOrangeBallChasers = BallChaserQueueBuilder.many(3, { team: Team.Orange });
       const mockBlueBallChasers = BallChaserQueueBuilder.many(2, { team: Team.Blue });
       const mockBallChaserNoTeam = BallChaserQueueBuilder.single({ team: null, isCap: false });
-      mockBallChasers.push(mockBallChaserNoTeam);
-      mockOrangeBallChasers.forEach((p) => {
-        mockBallChasers.push(p);
-      });
-      mockBlueBallChasers.forEach((p) => {
-        mockBallChasers.push(p);
-      });
+      const mockBallChasers: PlayerInQueue[] = [...mockOrangeBallChasers, ...mockBlueBallChasers, mockBallChaserNoTeam];
 
       jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
 

--- a/src/services/__tests__/MatchService.unit.spec.ts
+++ b/src/services/__tests__/MatchService.unit.spec.ts
@@ -1,8 +1,9 @@
 import { BallChaserQueueBuilder } from "../../../.jest/Builder";
-import { createRandomMatch } from "../MatchService";
+import { blueCaptainsChoice, createRandomMatch } from "../MatchService";
 import ActiveMatchRepository from "../../repositories/ActiveMatchRepository";
 import QueueRepository from "../../repositories/QueueRepository";
 import { Team } from "../../types/common";
+import faker from "faker";
 
 jest.mock("../../repositories/ActiveMatchRepository");
 jest.mock("../../repositories/QueueRepository");
@@ -13,33 +14,59 @@ beforeEach(() => {
 });
 
 describe("Match Service tests", () => {
-  it("random teams are created", async () => {
-    const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
-    jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+  describe("Random button was pressed", () => {
+    it("random teams are created", async () => {
+      const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
 
-    const players = await createRandomMatch();
+      const players = await createRandomMatch();
 
-    expect(players.filter((player) => player.team === Team.Orange)).toHaveLength(3);
-    expect(players.filter((player) => player.team === Team.Blue)).toHaveLength(3);
+      expect(players.filter((player) => player.team === Team.Orange)).toHaveLength(3);
+      expect(players.filter((player) => player.team === Team.Blue)).toHaveLength(3);
+    });
+    it("updates queue with update player teams", async () => {
+      const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+
+      await createRandomMatch();
+      const addMatchMock = jest.mocked(ActiveMatchRepository.addActiveMatch);
+
+      expect(addMatchMock).toHaveBeenCalled();
+    });
+    it("removes players from queue", async () => {
+      const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+
+      await createRandomMatch();
+      const removePlayersMock = jest.mocked(QueueRepository.removeAllBallChasersFromQueue);
+
+      expect(removePlayersMock).toHaveBeenCalled();
+    });
   });
+  describe("Captains button was pressed", () => {
+    it("captains are set", async () => {
+      const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null, isCap: false });
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+      jest.mocked(QueueRepository.updateBallChaserInQueue({ id: mockBallChasers[0].id, isCap: true, team: Team.Blue }));
+      jest.mocked(
+        QueueRepository.updateBallChaserInQueue({ id: mockBallChasers[1].id, isCap: true, team: Team.Orange })
+      );
 
-  it("updates queue with update player teams", async () => {
-    const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
-    jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+      const players = await blueCaptainsChoice(null);
 
-    await createRandomMatch();
-    const addMatchMock = jest.mocked(ActiveMatchRepository.addActiveMatch);
+      expect(players.filter((player) => player.team === Team.Orange)).toHaveLength(1);
+      expect(players.filter((player) => player.team === Team.Blue)).toHaveLength(1);
+      expect(players.filter((player) => player.isCap)).toHaveLength(2);
+    });
+    it("blue captains choice is set", async () => {
+      const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+      jest.mocked(QueueRepository.updateBallChaserInQueue({ id: mockBallChasers[2].id, isCap: true, team: Team.Blue }));
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+      const players = await blueCaptainsChoice(mockBallChasers[2].id);
 
-    expect(addMatchMock).toHaveBeenCalled();
-  });
-
-  it("removes players from queue", async () => {
-    const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
-    jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
-
-    await createRandomMatch();
-    const removePlayersMock = jest.mocked(QueueRepository.removeAllBallChasersFromQueue);
-
-    expect(removePlayersMock).toHaveBeenCalled();
+      expect(players.filter((player) => player.team === Team.Blue)).toHaveLength(2);
+    });
   });
 });

--- a/src/services/__tests__/TeamAssignmentService.unit.spec.ts
+++ b/src/services/__tests__/TeamAssignmentService.unit.spec.ts
@@ -1,18 +1,81 @@
-import { createRandomTeams } from "../TeamAssignmentService";
+import { bluePlayerChosen, createRandomTeams, orangePlayerChosen, setCaptains } from "../TeamAssignmentService";
 import { Team } from "../../types/common";
 import { BallChaserQueueBuilder } from "../../../.jest/Builder";
+import QueueRepository from "../../repositories/QueueRepository";
+import faker from "faker";
 
-const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
+jest.mock("../../repositories/QueueRepository");
 
-//Remove team values and mmr as they will be set below.
-mockBallChasers.forEach((player) => (player.team = null));
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("Team Assignment Service tests", () => {
-  it("splits teams equally in size", async () => {
-    const sortedBallChasers = await createRandomTeams(mockBallChasers);
+  describe("create random teams", () => {
+    it("splits teams equally in size", async () => {
+      const mockBallChasers = BallChaserQueueBuilder.many(6, { team: null });
+      const sortedBallChasers = await createRandomTeams(mockBallChasers);
 
-    expect(sortedBallChasers).toHaveLength(6);
-    expect(sortedBallChasers.filter((player) => player.team == Team.Orange)).toHaveLength(3);
-    expect(sortedBallChasers.filter((player) => player.team == Team.Blue)).toHaveLength(3);
+      expect(sortedBallChasers).toHaveLength(6);
+      expect(sortedBallChasers.filter((player) => player.team === Team.Orange)).toHaveLength(3);
+      expect(sortedBallChasers.filter((player) => player.team === Team.Blue)).toHaveLength(3);
+    });
+  });
+  describe("captains choose teams", () => {
+    it("captains are set", async () => {
+      const mockBallChasers = BallChaserQueueBuilder.many(6, { isCap: false });
+
+      await setCaptains(mockBallChasers);
+
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledTimes(2);
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledWith(
+        expect.objectContaining({
+          id: mockBallChasers[0].id,
+          isCap: true,
+          team: Team.Orange,
+        })
+      );
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledWith(
+        expect.objectContaining({
+          id: mockBallChasers[1].id,
+          isCap: true,
+          team: Team.Blue,
+        })
+      );
+    });
+    it("blue player is set after being chosen", async () => {
+      const playerId = faker.datatype.uuid();
+      await bluePlayerChosen(playerId);
+
+      const mockBallChasers = BallChaserQueueBuilder.many(6);
+      jest.mocked(QueueRepository.getAllBallChasersInQueue).mockResolvedValueOnce(mockBallChasers);
+
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledTimes(1);
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledWith(
+        expect.objectContaining({
+          id: playerId,
+          team: Team.Blue,
+        })
+      );
+      expect(QueueRepository.getAllBallChasersInQueue).toBeCalled();
+    });
+    it("orange player is set after being chosen", async () => {
+      const playerIds = [faker.datatype.uuid(), faker.datatype.uuid()];
+      await orangePlayerChosen(playerIds);
+
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledTimes(2);
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledWith(
+        expect.objectContaining({
+          id: playerIds[0],
+          team: Team.Orange,
+        })
+      );
+      expect(QueueRepository.updateBallChaserInQueue).toBeCalledWith(
+        expect.objectContaining({
+          id: playerIds[1],
+          team: Team.Orange,
+        })
+      );
+    });
   });
 });

--- a/src/utils/MessageBuilder.ts
+++ b/src/utils/MessageBuilder.ts
@@ -259,13 +259,13 @@ export default class MessageBuilder {
       } else if (player.team === Team.Orange) {
         orangeTeam.push("<@" + player.id + ">");
       } else {
-        availablePlayers.push({ description: "MMR:" + player.mmr, label: player.name, value: player.id });
+        availablePlayers.push({ description: "MMR: " + player.mmr, label: player.name, value: player.id });
       }
     });
 
     const playerChoices = new MessageSelectMenu()
       .setCustomId(MenuCustomID.BlueSelect)
-      .setPlaceholder(blueCaptain + " Choose a Player")
+      .setPlaceholder(blueCaptain + " choose a player")
       .addOptions(availablePlayers);
 
     embed
@@ -308,13 +308,13 @@ export default class MessageBuilder {
         }
         orangeTeam.push("<@" + player.id + ">");
       } else {
-        availablePlayers.push({ description: "MMR:" + player.mmr, label: player.name, value: player.id });
+        availablePlayers.push({ description: "MMR: " + player.mmr, label: player.name, value: player.id });
       }
     });
 
     const playerChoices = new MessageSelectMenu()
       .setCustomId(MenuCustomID.OrangeSelect)
-      .setPlaceholder(orangeCaptain + " Choose 2 Players")
+      .setPlaceholder(orangeCaptain + " choose 2 players")
       .setMinValues(2)
       .setMaxValues(2)
       .addOptions(availablePlayers);

--- a/src/utils/MessageBuilder.ts
+++ b/src/utils/MessageBuilder.ts
@@ -1,4 +1,12 @@
-import { ButtonInteraction, MessageActionRow, MessageButton, MessageEmbed, MessageOptions } from "discord.js";
+import {
+  ButtonInteraction,
+  MessageActionRow,
+  MessageButton,
+  MessageEmbed,
+  MessageOptions,
+  MessageSelectMenu,
+  MessageSelectOptionData,
+} from "discord.js";
 import { NewActiveMatchInput } from "../repositories/ActiveMatchRepository/types";
 import { Team } from "../types/common";
 import getEnvVariable from "./getEnvVariable";
@@ -8,10 +16,16 @@ export const enum ButtonCustomID {
   JoinQueue = "joinQueue",
   LeaveQueue = "leaveQueue",
   CreateRandomTeam = "randomizeTeams",
+  ChooseTeam = "chooseTeam",
   FillTeam = "fillTeam",
   ReportMatch = "reportMatch",
   RemoveAll = "removeAll",
   BreakMatch = "breakMatch",
+}
+
+export const enum MenuCustomID {
+  BlueSelect = "blueSelect",
+  OrangeSelect = "orangeSelect",
 }
 
 export default class MessageBuilder {
@@ -138,9 +152,14 @@ export default class MessageBuilder {
       color: "GREEN",
       thumbnail: { url: this.normIconURL },
     });
-    const pickTeamsButton = new MessageButton({
+    const randomTeamsButton = new MessageButton({
       customId: ButtonCustomID.CreateRandomTeam,
       label: "Random",
+      style: "PRIMARY",
+    });
+    const pickTeamsButton = new MessageButton({
+      customId: ButtonCustomID.ChooseTeam,
+      label: "Captains",
       style: "PRIMARY",
     });
     const leaveButton = new MessageButton({
@@ -168,8 +187,8 @@ export default class MessageBuilder {
 
     return {
       components: this.isDev
-        ? [new MessageActionRow({ components: [pickTeamsButton, leaveButton, removeAllButton] })]
-        : [new MessageActionRow({ components: [pickTeamsButton, leaveButton] })],
+        ? [new MessageActionRow({ components: [pickTeamsButton, randomTeamsButton, leaveButton, removeAllButton] })]
+        : [new MessageActionRow({ components: [pickTeamsButton, randomTeamsButton, leaveButton] })],
       embeds: [embed],
     };
   }
@@ -210,6 +229,106 @@ export default class MessageBuilder {
       components: this.isDev
         ? [new MessageActionRow({ components: [reportMatch, breakMatch] })]
         : [new MessageActionRow({ components: [reportMatch] })],
+      embeds: [embed],
+    };
+  }
+
+  static blueChooseMessage(ballChasers: ReadonlyArray<PlayerInQueue>): MessageOptions {
+    const embed = new MessageEmbed({
+      color: "BLUE",
+      thumbnail: { url: this.normIconURL },
+    });
+    const breakMatch = new MessageButton({
+      customId: ButtonCustomID.RemoveAll,
+      label: "DEV: Break Match",
+      style: "DANGER",
+    });
+
+    //Get Available Players and Map players
+    const availablePlayers: Array<MessageSelectOptionData> = [];
+    const orangeTeam: Array<string> = [];
+    const blueTeam: Array<string> = [];
+    let blueCaptain: string | null = null;
+
+    ballChasers.forEach((player) => {
+      if (player.team === Team.Blue) {
+        if (player.isCap) {
+          blueCaptain = player.name;
+        }
+        blueTeam.push("<@" + player.id + ">");
+      } else if (player.team === Team.Orange) {
+        orangeTeam.push("<@" + player.id + ">");
+      } else {
+        availablePlayers.push({ description: "MMR:" + player.mmr, label: player.name, value: player.id });
+      }
+    });
+
+    const playerChoices = new MessageSelectMenu()
+      .setCustomId(MenuCustomID.BlueSelect)
+      .setPlaceholder(blueCaptain + " Choose a Player")
+      .addOptions(availablePlayers);
+
+    embed
+      .setTitle("Captains pick your players")
+      .setDescription("🔷" + blueCaptain + "'s 🔷 chooses first")
+      .addField("🔷 Blue Team 🔷", "<@" + ballChasers[0].id + ">")
+      .addField("🔶 Orange Team 🔶", "<@" + ballChasers[1].id + ">");
+
+    return {
+      components: this.isDev
+        ? [new MessageActionRow({ components: [playerChoices] }), new MessageActionRow({ components: [breakMatch] })]
+        : [new MessageActionRow({ components: [playerChoices] })],
+      embeds: [embed],
+    };
+  }
+
+  static orangeChooseMessage(ballChasers: ReadonlyArray<PlayerInQueue>): MessageOptions {
+    const embed = new MessageEmbed({
+      color: "ORANGE",
+      thumbnail: { url: this.normIconURL },
+    });
+    const breakMatch = new MessageButton({
+      customId: ButtonCustomID.RemoveAll,
+      label: "DEV: Break Match",
+      style: "DANGER",
+    });
+
+    //Get Available Players and Map players
+    const availablePlayers: Array<MessageSelectOptionData> = [];
+    const orangeTeam: Array<string> = [];
+    const blueTeam: Array<string> = [];
+    let orangeCaptain: string | null = null;
+
+    ballChasers.forEach((player) => {
+      if (player.team === Team.Blue) {
+        blueTeam.push("<@" + player.id + ">");
+      } else if (player.team === Team.Orange) {
+        if (player.isCap) {
+          orangeCaptain = player.name;
+        }
+        orangeTeam.push("<@" + player.id + ">");
+      } else {
+        availablePlayers.push({ description: "MMR:" + player.mmr, label: player.name, value: player.id });
+      }
+    });
+
+    const playerChoices = new MessageSelectMenu()
+      .setCustomId(MenuCustomID.OrangeSelect)
+      .setPlaceholder(orangeCaptain + " Choose 2 Players")
+      .setMinValues(2)
+      .setMaxValues(2)
+      .addOptions(availablePlayers);
+
+    embed
+      .setTitle("Captains pick your players")
+      .setDescription("🔶" + orangeCaptain + "🔶 choose 2 players")
+      .addField("🔷 Blue Team 🔷", blueTeam.join("\n"))
+      .addField("🔶 Orange Team 🔶", orangeTeam.join("\n"));
+
+    return {
+      components: this.isDev
+        ? [new MessageActionRow({ components: [playerChoices] }), new MessageActionRow({ components: [breakMatch] })]
+        : [new MessageActionRow({ components: [playerChoices] })],
       embeds: [embed],
     };
   }

--- a/src/utils/MessageBuilder.ts
+++ b/src/utils/MessageBuilder.ts
@@ -157,7 +157,7 @@ export default class MessageBuilder {
       label: "Random",
       style: "PRIMARY",
     });
-    const pickTeamsButton = new MessageButton({
+    const pickCaptainsButton = new MessageButton({
       customId: ButtonCustomID.ChooseTeam,
       label: "Captains",
       style: "PRIMARY",
@@ -187,8 +187,8 @@ export default class MessageBuilder {
 
     return {
       components: this.isDev
-        ? [new MessageActionRow({ components: [pickTeamsButton, randomTeamsButton, leaveButton, removeAllButton] })]
-        : [new MessageActionRow({ components: [pickTeamsButton, randomTeamsButton, leaveButton] })],
+        ? [new MessageActionRow({ components: [pickCaptainsButton, randomTeamsButton, leaveButton, removeAllButton] })]
+        : [new MessageActionRow({ components: [pickCaptainsButton, randomTeamsButton, leaveButton] })],
       embeds: [embed],
     };
   }

--- a/src/utils/MessageBuilder.ts
+++ b/src/utils/MessageBuilder.ts
@@ -321,7 +321,7 @@ export default class MessageBuilder {
 
     embed
       .setTitle("Captains pick your players")
-      .setDescription("🔶" + orangeCaptain + "🔶 choose 2 players")
+      .setDescription("🔶 " + orangeCaptain + " 🔶 choose 2 players")
       .addField("🔷 Blue Team 🔷", blueTeam.join("\n"))
       .addField("🔶 Orange Team 🔶", orangeTeam.join("\n"));
 

--- a/src/utils/MessageBuilder.ts
+++ b/src/utils/MessageBuilder.ts
@@ -270,9 +270,9 @@ export default class MessageBuilder {
 
     embed
       .setTitle("Captains pick your players")
-      .setDescription("🔷" + blueCaptain + "'s 🔷 chooses first")
-      .addField("🔷 Blue Team 🔷", "<@" + ballChasers[0].id + ">")
-      .addField("🔶 Orange Team 🔶", "<@" + ballChasers[1].id + ">");
+      .setDescription("🔷 " + blueCaptain + " 🔷 chooses first")
+      .addField("🔷 Blue Team 🔷", blueTeam.join("\n"))
+      .addField("🔶 Orange Team 🔶", orangeTeam.join("\n"));
 
     return {
       components: this.isDev


### PR DESCRIPTION
This PR adds the Captains button to the full queue message.  When the captains button is chosen - the top two players are captains.  Blue captain who has first choice is the second highest MMR, and the orange captain is the highest mmr player.

![image](https://user-images.githubusercontent.com/14949544/156640247-59da6c08-6dc9-4cde-8bd3-fce8712d9957.png)

1) Blue captain chooses
![image](https://user-images.githubusercontent.com/14949544/156640292-4b60ba2c-1569-47e7-8f9e-1674a1454477.png)

2) Orange captain chooses two players
![image](https://user-images.githubusercontent.com/14949544/156640344-5b2e40f5-c7a4-4d7e-a3ac-22519a79ef3e.png)

3) The last person is assigned to blue team.
![image](https://user-images.githubusercontent.com/14949544/156640458-017061d4-4b1a-4619-b27d-e274cd350f28.png)


While players are being chosen the menu select item displays all available queue members like this:
![image](https://user-images.githubusercontent.com/14949544/156640555-51640b42-cf5c-459f-873b-4d6fdd1493a3.png)

After teams are chosen the active match embed is shown and the queue is cleared.  