### PR TITLE
Add stale queue timer check

### DIFF
--- a/src/controllers/QueueController.ts
+++ b/src/controllers/QueueController.ts
@@ -13,15 +13,14 @@ export function startQueueTimer(queueEmbed: Message) {
 
     if (updatedList) {
       await queueEmbed.edit(MessageBuilder.queueMessage(updatedList));
-    } else if (minuteCounter === 5) {
+      minuteCounter = 0;
+    } else if (minuteCounter >= 5) {
       const allPlayers = await QueueRepository.getAllBallChasersInQueue();
 
       if (allPlayers.length > 0) {
         await queueEmbed.edit(MessageBuilder.queueMessage(allPlayers));
       }
-    }
 
-    if (minuteCounter === 5) {
       minuteCounter = 0;
     }
     // every 1 minute

--- a/src/controllers/QueueController.ts
+++ b/src/controllers/QueueController.ts
@@ -1,0 +1,31 @@
+import { Message } from "discord.js";
+import QueueRepository from "../repositories/QueueRepository";
+import { checkQueueTimes } from "../services/QueueService";
+import MessageBuilder from "../utils/MessageBuilder";
+
+export function startQueueTimers(queueEmbed: Message) {
+  let minuteCounter = 0;
+
+  setInterval(() => {
+    minuteCounter++;
+
+    if (minuteCounter === 5) {
+      QueueRepository.getAllBallChasersInQueue()
+        .then((updatedList) => {
+          if (updatedList.length > 0) {
+            return queueEmbed.edit(MessageBuilder.queueMessage(updatedList));
+          }
+        })
+        .finally(() => {
+          minuteCounter = 0;
+        });
+    } else {
+      checkQueueTimes().then((updatedList) => {
+        if (updatedList) {
+          queueEmbed.edit(MessageBuilder.queueMessage(updatedList));
+        }
+      });
+    }
+    // every 1 minute
+  }, 1 * 60 * 1000);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { getEnvVariable } from "./utils";
 import { handleDevInteraction } from "./controllers/DevInteractions";
 import { handleAdminInteraction, registerAdminSlashCommands } from "./controllers/AdminController";
 import { handleMenuInteraction } from "./controllers/MenuInteractions";
-import { startQueueTimers } from "./controllers/QueueController";
+import { startQueueTimer } from "./controllers/QueueController";
 
 const NormClient = new Client({ intents: "GUILDS" });
 
@@ -45,7 +45,7 @@ NormClient.on("ready", async (client) => {
   await Promise.all([registerAdminCommandsPromise, updateLeaderboardPromise, postCurrentQueuePromise]);
 
   if (queueEmbed) {
-    startQueueTimers(queueEmbed);
+    startQueueTimer(queueEmbed);
   } else {
     console.warn("Unable to start queue timers since queue embed is null.");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { getEnvVariable } from "./utils";
 import { handleDevInteraction } from "./controllers/DevInteractions";
 import { handleAdminInteraction, registerAdminSlashCommands } from "./controllers/AdminController";
 import { handleMenuInteraction } from "./controllers/MenuInteractions";
+import { startQueueTimers } from "./controllers/QueueController";
 
 const NormClient = new Client({ intents: "GUILDS" });
 
@@ -42,6 +43,12 @@ NormClient.on("ready", async (client) => {
     });
 
   await Promise.all([registerAdminCommandsPromise, updateLeaderboardPromise, postCurrentQueuePromise]);
+
+  if (queueEmbed) {
+    startQueueTimers(queueEmbed);
+  } else {
+    console.warn("Unable to start queue timers since queue embed is null.");
+  }
 });
 
 NormClient.on("interactionCreate", async (interaction) => {

--- a/src/services/QueueService.ts
+++ b/src/services/QueueService.ts
@@ -2,6 +2,7 @@ import { DateTime } from "luxon";
 import ActiveMatchRepository from "../repositories/ActiveMatchRepository";
 import QueueRepository from "../repositories/QueueRepository";
 import { PlayerInQueue } from "../repositories/QueueRepository/types";
+import { waitForAllPromises } from "../utils";
 
 export async function joinQueue(userId: string, userName: string): Promise<ReadonlyArray<PlayerInQueue> | null> {
   //Check if in Active Match so as not to add to the queue.
@@ -28,5 +29,21 @@ export async function joinQueue(userId: string, userName: string): Promise<Reado
 
 export async function leaveQueue(userId: string): Promise<ReadonlyArray<PlayerInQueue>> {
   await QueueRepository.removeBallChaserFromQueue(userId);
+  return await QueueRepository.getAllBallChasersInQueue();
+}
+
+export async function checkQueueTimes(): Promise<ReadonlyArray<PlayerInQueue> | null> {
+  const allPlayers = await QueueRepository.getAllBallChasersInQueue();
+
+  const queueIsPopped = allPlayers.some((p) => p.isCap);
+  const playersToRemove = allPlayers.filter((p) => p.queueTime.diffNow().as("minutes") <= 0);
+
+  if (playersToRemove.length === 0 || queueIsPopped) {
+    return null;
+  }
+
+  await waitForAllPromises(playersToRemove, async (player) => {
+    await QueueRepository.removeBallChaserFromQueue(player.id);
+  });
   return await QueueRepository.getAllBallChasersInQueue();
 }


### PR DESCRIPTION
Closes #16.

## Description
This work adds a timer that runs every minute. Every 5 minutes the queue embed is updated with the latest queue times. Every minute the queue is checked to see if anyone needs to be removed from the queue. If anyone is removed, the embed is updated right away.

## Changes
 - `QueueController.ts` - New controller for setting up the timeout.
 - `index.ts` - Start timeout on bot startup.
 - `QueueService.ts` - Add function to remove stale queue players if any.