### PR TITLE
Add admin commands for force broken queue and update mmr multiplier

### DIFF
--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -4,15 +4,22 @@ import { REST } from "@discordjs/rest";
 import { RESTPostAPIApplicationCommandsJSONBody, Routes } from "discord-api-types/v9";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import MessageBuilder from "../utils/MessageBuilder";
-import { kickPlayerFromQueue } from "../services/AdminService";
+import { kickPlayerFromQueue, updateMmrMultiplier } from "../services/AdminService";
 import { InvalidCommand } from "../utils/InvalidCommand";
+import ActiveMatchRepository from "../repositories/ActiveMatchRepository";
+import { isActiveMatchEmbed, isQueueEmbed } from "../utils/discordUtils";
 
 const enum AdminCommandOptions {
   Kick = "kick",
   Clear = "clear",
+  ForceBrokenQueue = "forcebrokenq",
+  MmrMultiplier = "mmrmult",
 }
 
-export async function handleAdminInteraction(slashCommandInteraction: CommandInteraction, queueEmbed: Message) {
+export async function handleAdminInteraction(
+  slashCommandInteraction: CommandInteraction,
+  queueMessages: Array<Message>
+) {
   const memberRoles = slashCommandInteraction.member?.roles;
   if (
     !memberRoles ||
@@ -34,8 +41,10 @@ export async function handleAdminInteraction(slashCommandInteraction: CommandInt
       try {
         const updatedList = await kickPlayerFromQueue(playerToRemove.id);
 
+        const queueEmbed = queueMessages.find((msg) => isQueueEmbed(msg));
+
         await Promise.all([
-          queueEmbed.edit(MessageBuilder.queueMessage(updatedList)),
+          queueEmbed?.edit(MessageBuilder.queueMessage(updatedList)),
           slashCommandInteraction.editReply(`${playerToRemove.username} has been removed from the queue.`),
         ]);
       } catch (err) {
@@ -48,14 +57,60 @@ export async function handleAdminInteraction(slashCommandInteraction: CommandInt
 
       break;
     }
-    case AdminCommandOptions.Clear:
+    case AdminCommandOptions.Clear: {
       // leaving this out of the Promise.all in case it fails we don't want to do the other two
       await QueueRepository.removeAllBallChasersFromQueue();
+
+      const queueEmbed = queueMessages.find((msg) => isQueueEmbed(msg));
+      if (!queueEmbed) throw new Error("No queue embed to update.");
+
       await Promise.all([
         queueEmbed.edit(MessageBuilder.queueMessage([])),
         slashCommandInteraction.editReply("Queue has been cleared."),
       ]);
       break;
+    }
+    case AdminCommandOptions.ForceBrokenQueue: {
+      const player = slashCommandInteraction.options.getUser("player");
+      if (!player) return;
+
+      try {
+        await ActiveMatchRepository.removeAllPlayersInActiveMatch(player.id);
+
+        const activeMatchEmbed = queueMessages.find((msg) => {
+          return isActiveMatchEmbed(msg) && msg.embeds[0].fields.some((field) => field.value.includes(player.id));
+        });
+
+        await Promise.all([
+          slashCommandInteraction.editReply("Active match has been removed."),
+          activeMatchEmbed?.delete(),
+        ]);
+      } catch (err) {
+        if (err instanceof InvalidCommand) {
+          await slashCommandInteraction.editReply(
+            `Error trying to remove match with ${player.username}.\n${err.name}: ${err.message}`
+          );
+        }
+      }
+      break;
+    }
+    case AdminCommandOptions.MmrMultiplier: {
+      const newMmrMult = slashCommandInteraction.options.getNumber("mmr");
+      // has to be strict null check since 0 would evaluate to true but is allowed
+      if (newMmrMult === null) return;
+
+      try {
+        await updateMmrMultiplier(newMmrMult);
+        await slashCommandInteraction.editReply(`MMR multiplier has been set to ${newMmrMult}.`);
+      } catch (err) {
+        if (err instanceof InvalidCommand) {
+          await slashCommandInteraction.editReply(
+            `Error trying to update MMR multiplier to ${newMmrMult}.\n${err.name}: ${err.message}`
+          );
+        }
+      }
+      break;
+    }
   }
 }
 
@@ -75,8 +130,29 @@ export async function registerAdminSlashCommands(clientId: string, guildId: stri
     .setDescription("Clears the queue.")
     .toJSON();
 
+  const brokenQueueCommand = new SlashCommandBuilder()
+    .setName(AdminCommandOptions.ForceBrokenQueue)
+    .setDescription("Removes an active match without reporting a winner.")
+    .addUserOption((option) => {
+      return option.setName("player").setDescription("One of the players in the match to remove.").setRequired(true);
+    })
+    .toJSON();
+
+  const mmrMultiplierCommand = new SlashCommandBuilder()
+    .setName(AdminCommandOptions.MmrMultiplier)
+    .setDescription("Update the MMR multiplier.")
+    .addNumberOption((option) => {
+      return option.setName("mmr").setDescription("New MMR multiplier.").setMinValue(0).setRequired(true);
+    })
+    .toJSON();
+
   try {
-    const commands: Array<RESTPostAPIApplicationCommandsJSONBody> = [kickCommand, clearCommand];
+    const commands: Array<RESTPostAPIApplicationCommandsJSONBody> = [
+      brokenQueueCommand,
+      clearCommand,
+      kickCommand,
+      mmrMultiplierCommand,
+    ];
 
     await rest.put(Routes.applicationGuildCommands(clientId, guildId), { body: commands });
   } catch (error) {

--- a/src/controllers/Interactions.ts
+++ b/src/controllers/Interactions.ts
@@ -6,9 +6,9 @@ import { PlayerInQueue } from "../repositories/QueueRepository/types";
 import QueueRepository from "../repositories/QueueRepository";
 import { setCaptains } from "../services/TeamAssignmentService";
 
-export async function postCurrentQueue(queueChannel: TextChannel): Promise<Message> {
+export async function postCurrentQueue(queueChannel: TextChannel): Promise<void> {
   const ballchasers = await QueueRepository.getAllBallChasersInQueue();
-  return await queueChannel.send(MessageBuilder.queueMessage(ballchasers));
+  await queueChannel.send(MessageBuilder.queueMessage(ballchasers));
 }
 
 export async function handleInteraction(buttonInteraction: ButtonInteraction): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,21 @@
-import { Client, Message } from "discord.js";
+import { Client, Intents, Message } from "discord.js";
 import { updateLeaderboardChannel } from "./controllers/LeaderboardChannelController";
 import { handleInteraction, postCurrentQueue } from "./controllers/Interactions";
-import { getDiscordChannelById } from "./utils/discordUtils";
+import { getDiscordChannelById, isQueueEmbed } from "./utils/discordUtils";
 import { getEnvVariable } from "./utils";
 import { handleDevInteraction } from "./controllers/DevInteractions";
 import { handleAdminInteraction, registerAdminSlashCommands } from "./controllers/AdminController";
 import { handleMenuInteraction } from "./controllers/MenuInteractions";
 import { startQueueTimer } from "./controllers/QueueController";
 
-const NormClient = new Client({ intents: "GUILDS" });
+const NormClient = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
 const guildId = getEnvVariable("guild_id");
 const leaderboardChannelId = getEnvVariable("leaderboard_channel_id");
 const queueChannelId = getEnvVariable("queue_channel_id");
 const discordToken = getEnvVariable("token");
 
-let queueEmbed: Message | null;
+const queueMessages: Array<Message> = [];
 
 // function called on startup
 NormClient.on("ready", async (client) => {
@@ -32,18 +32,15 @@ NormClient.on("ready", async (client) => {
     }
   );
 
-  const postCurrentQueuePromise = getDiscordChannelById(NormClient, queueChannelId)
-    .then((queueChannel) => {
-      if (queueChannel) {
-        return postCurrentQueue(queueChannel);
-      }
-    })
-    .then((queueEmbedMsg) => {
-      queueEmbed = queueEmbedMsg ?? null;
-    });
+  const postCurrentQueuePromise = getDiscordChannelById(NormClient, queueChannelId).then((queueChannel) => {
+    if (queueChannel) {
+      return postCurrentQueue(queueChannel);
+    }
+  });
 
   await Promise.all([registerAdminCommandsPromise, updateLeaderboardPromise, postCurrentQueuePromise]);
 
+  const queueEmbed = queueMessages.find((msg) => isQueueEmbed(msg));
   if (queueEmbed) {
     startQueueTimer(queueEmbed);
   } else {
@@ -62,11 +59,16 @@ NormClient.on("interactionCreate", async (interaction) => {
 
     await handleMenuInteraction(interaction);
   } else if (interaction.isCommand()) {
-    if (!queueEmbed) throw new Error("No queue embed set.");
-
     await interaction.deferReply({ ephemeral: true });
-    await handleAdminInteraction(interaction, queueEmbed);
+    await handleAdminInteraction(interaction, queueMessages);
   }
+});
+
+NormClient.on("messageCreate", (msg) => {
+  if (!NormClient.user) throw new Error("No client id");
+  if (msg.author.id !== NormClient.user.id || msg.embeds.length === 0 || msg.channelId !== queueChannelId) return;
+
+  queueMessages.push(msg);
 });
 
 NormClient.login(discordToken);

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,4 +71,11 @@ NormClient.on("messageCreate", (msg) => {
   queueMessages.push(msg);
 });
 
+NormClient.on("messageDelete", (msg) => {
+  const msgIndex = queueMessages.findIndex((qMsg) => qMsg.id === msg.id);
+  if (msgIndex > -1) {
+    queueMessages.splice(msgIndex);
+  }
+});
+
 NormClient.login(discordToken);

--- a/src/repositories/ActiveMatchRepository/__tests__/ActiveMatchRepository.int.spec.ts
+++ b/src/repositories/ActiveMatchRepository/__tests__/ActiveMatchRepository.int.spec.ts
@@ -5,6 +5,7 @@ import { PlayerInActiveMatch } from "../types";
 import { Team } from "../../../types/common";
 import { ActiveMatch, BallChaser, PrismaClient } from "@prisma/client";
 import { waitForAllPromises } from "../../../utils";
+import { InvalidCommand } from "../../../utils/InvalidCommand";
 
 let prisma: PrismaClient;
 
@@ -185,6 +186,12 @@ describe("ActiveMatchRepository Tests", () => {
       await expect(
         ActiveMatchRepository.updatePlayerInActiveMatch(BallChaserQueueBuilder.single().id, { reportedTeam: Team.Blue })
       ).rejects.toThrowError();
+    });
+
+    it("throws when trying to remove someone that doesn't exist", async () => {
+      await expect(
+        ActiveMatchRepository.removeAllPlayersInActiveMatch(BallChaserQueueBuilder.single().id)
+      ).rejects.toThrowError(InvalidCommand);
     });
   });
 });

--- a/src/repositories/EventRepository/EventRepository.ts
+++ b/src/repositories/EventRepository/EventRepository.ts
@@ -10,6 +10,15 @@ class EventRepository {
     this.#CurrentEventCache = null;
   }
 
+  /**
+   * @deprecated
+   * FOR TESTING PURPOSES ONLY
+   * DO NOT USE
+   */
+  resetCache(): void {
+    this.#CurrentEventCache = null;
+  }
+
   async getCurrentEvent(): Promise<Event> {
     if (this.#CurrentEventCache) {
       return this.#CurrentEventCache;

--- a/src/repositories/EventRepository/EventRepository.ts
+++ b/src/repositories/EventRepository/EventRepository.ts
@@ -1,8 +1,8 @@
 import { Prisma, PrismaClient } from "@prisma/client";
-import { Event } from "./types";
+import { Event, UpdateEventInput } from "./types";
 
 class EventRepository {
-  #Event: Prisma.EventDelegate<Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined>;
+  #Event: Prisma.EventDelegate<Prisma.RejectPerOperation>;
   #CurrentEventCache: Event | null;
 
   constructor() {
@@ -36,6 +36,20 @@ class EventRepository {
     this.#CurrentEventCache = currentEvent;
 
     return currentEvent;
+  }
+
+  async updateCurrentEvent(eventUpdates: UpdateEventInput): Promise<void> {
+    await this.getCurrentEvent().then((currEvent) => {
+      return this.#Event.update({
+        data: {
+          mmrMult: eventUpdates.mmrMult,
+          name: eventUpdates.name,
+        },
+        where: {
+          id: currEvent.id,
+        },
+      });
+    });
   }
 }
 

--- a/src/repositories/EventRepository/types.ts
+++ b/src/repositories/EventRepository/types.ts
@@ -5,3 +5,8 @@ export interface Event {
   endDate: Date | null;
   mmrMult: number;
 }
+
+export interface UpdateEventInput {
+  name?: string;
+  mmrMult?: number;
+}

--- a/src/services/AdminService.ts
+++ b/src/services/AdminService.ts
@@ -1,3 +1,4 @@
+import EventRepository from "../repositories/EventRepository";
 import QueueRepository from "../repositories/QueueRepository";
 import { PlayerInQueue } from "../repositories/QueueRepository/types";
 import { InvalidCommand } from "../utils/InvalidCommand";
@@ -12,4 +13,14 @@ export async function kickPlayerFromQueue(playerIdToRemove: string): Promise<Rea
   }
 
   return await leaveQueue(playerIdToRemove);
+}
+
+export async function updateMmrMultiplier(newMmrMult: number): Promise<void> {
+  if (newMmrMult < 0) {
+    throw new InvalidCommand("Cannot use a negative MMR multiplier.");
+  }
+
+  return await EventRepository.updateCurrentEvent({
+    mmrMult: newMmrMult,
+  });
 }

--- a/src/utils/__tests__/discordUtils.unit.spec.ts
+++ b/src/utils/__tests__/discordUtils.unit.spec.ts
@@ -1,0 +1,39 @@
+import { Message } from "discord.js";
+import { ActiveMatchBuilder, BallChaserQueueBuilder } from "../../../.jest/Builder";
+import { Team } from "../../types/common";
+import { isQueueEmbed, isActiveMatchEmbed } from "../discordUtils";
+import MessageBuilder from "../MessageBuilder";
+
+jest.mock("../utils");
+
+describe("Check Embed tests", () => {
+  const ballChasers = BallChaserQueueBuilder.many(1);
+  const activeMatchBlue = ActiveMatchBuilder.many(1, { team: Team.Blue });
+  const activeMatchOrange = ActiveMatchBuilder.many(1, { team: Team.Orange });
+  const activeMatch = [...activeMatchBlue, ...activeMatchOrange];
+
+  it.each([MessageBuilder.queueMessage(ballChasers), MessageBuilder.fullQueueMessage(ballChasers)])(
+    "identifies embed as queue embed",
+    (messageOptions) => {
+      // this is why I hate testing Discord stuff
+      expect(isQueueEmbed(messageOptions as unknown as Message)).toBeTruthy();
+    }
+  );
+
+  it("identifies embed as not a queue embed", () => {
+    const messageOptions = MessageBuilder.activeMatchMessage(activeMatch);
+    expect(isQueueEmbed(messageOptions as unknown as Message)).toBeFalsy();
+  });
+
+  it("identifies embed as an active match embed", () => {
+    const messageOptions = MessageBuilder.activeMatchMessage(activeMatch);
+    expect(isActiveMatchEmbed(messageOptions as unknown as Message)).toBeTruthy();
+  });
+
+  it.each([MessageBuilder.queueMessage(ballChasers), MessageBuilder.fullQueueMessage(ballChasers)])(
+    "identifies embed as not an active match embed",
+    (messageOptions) => {
+      expect(isActiveMatchEmbed(messageOptions as unknown as Message)).toBeFalsy();
+    }
+  );
+});

--- a/src/utils/discordUtils.ts
+++ b/src/utils/discordUtils.ts
@@ -1,4 +1,4 @@
-import { Client, TextChannel } from "discord.js";
+import { Client, Message, TextChannel } from "discord.js";
 
 export async function deleteAllMessagesInTextChannel(channel: TextChannel): Promise<void> {
   await channel.messages.fetch({ limit: 99 }).then((messages) => channel.bulkDelete(messages));
@@ -22,4 +22,12 @@ export async function getDiscordChannelById(
   }
 
   return null;
+}
+
+export function isQueueEmbed(msg: Message): boolean {
+  return msg.embeds[0].color === 5763719;
+}
+
+export function isActiveMatchEmbed(msg: Message): boolean {
+  return msg.embeds[0].color === 10038562;
 }


### PR DESCRIPTION
Closes #26.

## Description
This work adds admin slash commands for force breaking a queue (removing an active match) and setting the MMR multiplier for the current event.

Re-did the way we track messages sent by Norm. Before we only cared about the one queue embed. Now with force broken queue, we also need to track active match embeds. To do this, I added some event handlers for `messageCreate` and `messageDelete`. On `messageCreate` we add the message to an array stored locally called `queueMessages`. On `messageDelete` we look in `queueMessages` for the same message and remove it from the array if the embed is there.
This way we can look through all of the embeds in the queue channel and find the one that's relevant to the admin command when needed.

## Changes
 - `AdminController.ts` - Add new commands, refactor to use new message tracking implementation and add new command functionality.
 - `Interactions.ts` - Revert back to returning void since the way we track the queue embed has changed in `index.ts`.
 - `index.ts` - Add `messageCreate` and `messageDelete` event handlers and logic for keeping `queueMessages` up to date.
 - `ActiveMatchRepository.ts` - Slight adjustment to how "player not in an active match" is handled to better align with similar implementations elsewhere in the codebase.
 - `EventRepository.ts` - Add method for updating the current event.
 - `AdminService.ts` - Add function to handle error checking when setting the mmr multiplier.
 - `discordUtils.ts` - Added some functions to help with determining the type of embed that was sent. It matches based off color. I'm not a fan of doing it this way, but I couldn't think of a better solution. I even asked the Discord.js Discord and got very little help. To ease my worry I added some unit tests to make sure these checks work the way we expect.